### PR TITLE
Add type hints to prevent reflection

### DIFF
--- a/src/tablecloth/time/index.clj
+++ b/src/tablecloth/time/index.clj
@@ -2,15 +2,17 @@
   (:import java.util.TreeMap)
   (:require [tablecloth.api :as tablecloth]))
 
+(set! *warn-on-reflection* true)
+
 (defn make-index
   "Returns an index for `dataset` based on the specified `index-column-key`."
   [dataset index-column-key]
-  (-> dataset
-      (tablecloth/rows :as-maps)
-      (->> (map-indexed (fn [row-number row-map]
-                          [(index-column-key row-map) row-number]))
-           (into {})
-           (TreeMap.))))
+  (let [row-maps (-> dataset (tablecloth/rows :as-maps))
+        idx-map (->> row-maps
+                     (map-indexed (fn [row-number row-map]
+                                    [(index-column-key row-map) row-number]))
+                     (into {}))]
+    (TreeMap. ^java.util.Map idx-map)))
 
 (defn index-by
   "Returns a dataset with an index attached as metadata."

--- a/src/tablecloth/time/operations.clj
+++ b/src/tablecloth/time/operations.clj
@@ -1,13 +1,16 @@
 (ns tablecloth.time.operations
+  (:import java.util.TreeMap)
   (:require [tablecloth.time.index :refer [get-index-meta]]
             [tablecloth.api :as tablecloth]
             [tech.v3.datatype.errors :as errors]
             [tick.alpha.api :as t]))
 
+(set! *warn-on-reflection* true)
+
 ;; This method treats the from/to keys naively. When we attempt
 ;; to unify the API into a single slice method this may go away.
 (defn get-slice [dataset from to]
-  (let [index (get-index-meta dataset)
+  (let [^TreeMap index (get-index-meta dataset)
         row-numbers (if (not index)
                       (throw (Exception. "Dataset has no index specified."))
                       (-> index (.subMap from true to true) (.values)))]
@@ -15,7 +18,7 @@
 
 ;; TODO Write single `slice` method to handle all time units
 
-(defn slice-by-year [dataset from to]
+(defn slice-by-year [dataset ^String from  ^String to]
   (let [from-year (t/year from)
         to-year (t/year to)]
     (get-slice dataset from-year to-year)))


### PR DESCRIPTION
### Goal / Purpose

Per @daslu 's suggestion on #2 , it's a good idea to add type hints to avoid java reflection warnings. 

### Solution

Activates reflection warnings and adds type hints where needed. One challenging fn to type was the `make-index` function. I  had to ask a question in stackoverflow in the end to understand how to type it! (See [here](https://stackoverflow.com/questions/65676456/how-can-i-add-a-typehint-in-clojure-to-fix-ctor-cant-be-resolved-reflection-w))