### PR TITLE
Add simplification for slice api

### DIFF
--- a/src/tablecloth/time/index.clj
+++ b/src/tablecloth/time/index.clj
@@ -14,6 +14,13 @@
                      (into {}))]
     (TreeMap. ^java.util.Map idx-map)))
 
+(defn slice-index [dataset from to]
+  (let [^TreeMap index (get-index-meta dataset)
+        row-numbers (if (not index)
+                      (throw (Exception. "Dataset has no index specified."))
+                      (-> index (.subMap from true to true) (.values)))]
+    (tablecloth/select-rows dataset row-numbers)))
+
 (defn index-by
   "Returns a dataset with an index attached as metadata."
   [dataset index-column]

--- a/src/tablecloth/time/index.clj
+++ b/src/tablecloth/time/index.clj
@@ -23,4 +23,9 @@
 (defn get-index-meta [dataset]
   (-> dataset meta :index))
 
+;; Better to name this get-index-key-type?
+(defn get-index-type [dataset]
+  (let [^TreeMap index (-> dataset get-index-meta)]
+    (-> index .firstKey class)))
+
 

--- a/src/tablecloth/time/index.clj
+++ b/src/tablecloth/time/index.clj
@@ -4,6 +4,14 @@
 
 (set! *warn-on-reflection* true)
 
+(defn get-index-meta [dataset]
+  (-> dataset meta :index))
+
+;; Better to name this get-index-key-type?
+(defn get-index-type [dataset]
+  (let [^TreeMap index (-> dataset get-index-meta)]
+    (-> index .firstKey class)))
+
 (defn make-index
   "Returns an index for `dataset` based on the specified `index-column-key`."
   [dataset index-column-key]
@@ -27,12 +35,5 @@
   (let [index (make-index dataset index-column)]
     (vary-meta dataset assoc :index index)))
 
-(defn get-index-meta [dataset]
-  (-> dataset meta :index))
-
-;; Better to name this get-index-key-type?
-(defn get-index-type [dataset]
-  (let [^TreeMap index (-> dataset get-index-meta)]
-    (-> index .firstKey class)))
 
 

--- a/src/tablecloth/time/index.clj
+++ b/src/tablecloth/time/index.clj
@@ -2,15 +2,17 @@
   (:import java.util.TreeMap)
   (:require [tablecloth.api :as tablecloth]))
 
+(set! *warn-on-reflection* true)
+
 (defn make-index
   "Returns an index for `dataset` based on the specified `index-column-key`."
   [dataset index-column-key]
-  (-> dataset
-      (tablecloth/rows :as-maps)
-      (->> (map-indexed (fn [row-number row-map]
-                          [(index-column-key row-map) row-number]))
-           (into {})
-           (TreeMap.))))
+  (let [row-maps (-> dataset (tablecloth/rows :as-maps))
+        idx-map (->> row-maps
+                     (map-indexed (fn [row-number row-map]
+                                    [(index-column-key row-map) row-number]))
+                     (into {}))]
+    (TreeMap. ^java.util.Map idx-map)))
 
 (defn index-by
   "Returns a dataset with an index attached as metadata."

--- a/src/tablecloth/time/operations.clj
+++ b/src/tablecloth/time/operations.clj
@@ -43,7 +43,7 @@
   (java.time.Year/parse date-str))
 
 (defn slice
-  "Returns a subset of dataset's row as specified by from and to, inclusively.
+  "Returns a subset of dataset's rows as specified by from and to, inclusively.
   From and to are either strings or datetime type literals (e.g. #time/local-date \"1970-01-01\").
   The dataset must have been indexed, and the time unit of the index must match the unit of time
   by which you are attempting to slice.

--- a/src/tablecloth/time/operations.clj
+++ b/src/tablecloth/time/operations.clj
@@ -16,10 +16,18 @@
                       (-> index (.subMap from true to true) (.values)))]
     (tablecloth/select-rows dataset row-numbers)))
 
-;; TODO Write single `slice` method to handle all time units
-
 (defmulti parse-datetime-str
   (fn [datetime-datatype _] datetime-datatype))
+
+(defmethod parse-datetime-str
+  java.time.Instant
+  [_ date-str]
+  (java.time.Instant/parse date-str))
+
+(defmethod parse-datetime-str
+  java.time.ZonedDateTime
+  [_ date-str]
+  (java.time.ZonedDateTime/parse date-str))
 
 (defmethod parse-datetime-str
   java.time.LocalDate

--- a/src/tablecloth/time/operations.clj
+++ b/src/tablecloth/time/operations.clj
@@ -79,7 +79,9 @@
                  (instance? java.time.temporal.Temporal to) to
                  :else (parse-datetime-str time-unit to))]
     (cond
-      (not= time-unit (class from-key)) (throw (Exception. (format "Time unit of `from` does not match index time unit: %s" time-unit)))
-      (not= time-unit (class to-key)) (throw (Exception. (format "Time unit of `to` does not match index time unit: %s" time-unit)))
+      (not= time-unit (class from-key))
+      (throw (Exception. (format "Time unit of `from` does not match index time unit: %s" time-unit)))
+      (not= time-unit (class to-key))
+      (throw (Exception. (format "Time unit of `to` does not match index time unit: %s" time-unit)))
       :else (slice-index dataset from-key to-key))))
 

--- a/src/tablecloth/time/operations.clj
+++ b/src/tablecloth/time/operations.clj
@@ -1,20 +1,11 @@
 (ns tablecloth.time.operations
   (:import java.util.TreeMap)
-  (:require [tablecloth.time.index :refer [get-index-meta get-index-type]]
+  (:require [tablecloth.time.index :refer [get-index-type slice-index]]
             [tablecloth.api :as tablecloth]
             [tech.v3.datatype.errors :as errors]
             [tick.alpha.api :as t]))
 
 (set! *warn-on-reflection* true)
-
-;; This method treats the from/to keys naively. When we attempt
-;; to unify the API into a single slice method this may go away.
-(defn get-slice [dataset from to]
-  (let [^TreeMap index (get-index-meta dataset)
-        row-numbers (if (not index)
-                      (throw (Exception. "Dataset has no index specified."))
-                      (-> index (.subMap from true to true) (.values)))]
-    (tablecloth/select-rows dataset row-numbers)))
 
 (defmulti parse-datetime-str
   (fn [datetime-datatype _] datetime-datatype))
@@ -48,6 +39,6 @@
   (let [time-unit (get-index-type dataset)
         from-key (parse-datetime-str time-unit from)
         to-key (parse-datetime-str time-unit to)]
-    (get-slice dataset from-key to-key)))
+    (slice-index dataset from-key to-key)))
 
 

--- a/src/tablecloth/time/operations.clj
+++ b/src/tablecloth/time/operations.clj
@@ -7,6 +7,8 @@
 
 (set! *warn-on-reflection* true)
 
+;; TODO Would it be better to do this with a map instead of a mutlimethod?
+
 (defmulti parse-datetime-str
   (fn [datetime-datatype _] datetime-datatype))
 

--- a/src/tablecloth/time/operations.clj
+++ b/src/tablecloth/time/operations.clj
@@ -1,13 +1,16 @@
 (ns tablecloth.time.operations
+  (:import java.util.TreeMap)
   (:require [tablecloth.time.index :refer [get-index-meta]]
             [tablecloth.api :as tablecloth]
             [tech.v3.datatype.errors :as errors]
             [tick.alpha.api :as t]))
 
+(set! *warn-on-reflection* true)
+
 ;; This method treats the from/to keys naively. When we attempt
 ;; to unify the API into a single slice method this may go away.
 (defn get-slice [dataset from to]
-  (let [index (get-index-meta dataset)
+  (let [^TreeMap index (get-index-meta dataset)
         row-numbers (if (not index)
                       (throw (Exception. "Dataset has no index specified."))
                       (-> index (.subMap from true to true) (.values)))]
@@ -15,7 +18,7 @@
 
 ;; TODO Write single `slice` method to handle all time units
 
-(defn slice-by-year [dataset from to]
+(defn slice-by-year [dataset ^String from  ^String to]
   (let [from-year (t/year from)
         to-year (t/year to)]
     (get-slice dataset from-year to-year)))

--- a/src/tablecloth/time/operations.clj
+++ b/src/tablecloth/time/operations.clj
@@ -26,6 +26,11 @@
   (java.time.LocalDate/parse date-str))
 
 (defmethod parse-datetime-str
+  java.time.LocalDateTime
+  [_ date-str]
+  (java.time.LocalDateTime/parse date-str))
+
+(defmethod parse-datetime-str
   java.time.YearMonth
   [_ date-str]
   (java.time.YearMonth/parse date-str))

--- a/src/tablecloth/time/operations.clj
+++ b/src/tablecloth/time/operations.clj
@@ -72,6 +72,14 @@
   "
   [dataset from to]
   (let [time-unit (get-index-type dataset)
-        from-key (parse-datetime-str time-unit from)
-        to-key (parse-datetime-str time-unit to)]
-    (slice-index dataset from-key to-key)))
+        from-key (cond
+                   (instance? java.time.temporal.Temporal from) from
+                   :else (parse-datetime-str time-unit from))
+        to-key (cond
+                 (instance? java.time.temporal.Temporal to) to
+                 :else (parse-datetime-str time-unit to))]
+    (cond
+      (not= time-unit (class from-key)) (throw (Exception. (format "Time unit of `from` does not match index time unit: %s" time-unit)))
+      (not= time-unit (class to-key)) (throw (Exception. (format "Time unit of `to` does not match index time unit: %s" time-unit)))
+      :else (slice-index dataset from-key to-key))))
+

--- a/src/tablecloth/time/operations.clj
+++ b/src/tablecloth/time/operations.clj
@@ -42,10 +42,36 @@
   [_ date-str]
   (java.time.Year/parse date-str))
 
-(defn slice [dataset from to]
+(defn slice
+  "Returns a subset of dataset's row as specified by from and to, inclusively.
+  From and to are either strings or datetime type literals (e.g. #time/local-date \"1970-01-01\").
+  The dataset must have been indexed, and the time unit of the index must match the unit of time
+  by which you are attempting to slice.
+
+  Example data:
+
+  |   :A | :B |
+  |------|----|
+  | 1970 |  0 |
+  | 1971 |  1 |
+  | 1972 |  2 |
+  | 1973 |  3 |
+
+  Example:
+
+  (-> data
+      (index-by :A)
+      (slice \"1972\" \"1973\"))
+
+  ;; => _unnamed [2 2]:
+
+  |   :A | :B |
+  |------|----|
+  | 1972 |  2 |
+  | 1973 |  3 |
+  "
+  [dataset from to]
   (let [time-unit (get-index-type dataset)
         from-key (parse-datetime-str time-unit from)
         to-key (parse-datetime-str time-unit to)]
     (slice-index dataset from-key to-key)))
-
-

--- a/src/tablecloth/time/operations.clj
+++ b/src/tablecloth/time/operations.clj
@@ -12,33 +12,27 @@
 (defmulti parse-datetime-str
   (fn [datetime-datatype _] datetime-datatype))
 
-(defmethod parse-datetime-str
-  java.time.Instant
+(defmethod parse-datetime-str java.time.Instant
   [_ date-str]
   (java.time.Instant/parse date-str))
 
-(defmethod parse-datetime-str
-  java.time.ZonedDateTime
+(defmethod parse-datetime-str java.time.ZonedDateTime
   [_ date-str]
   (java.time.ZonedDateTime/parse date-str))
 
-(defmethod parse-datetime-str
-  java.time.LocalDate
+(defmethod parse-datetime-str java.time.LocalDate
   [_ date-str]
   (java.time.LocalDate/parse date-str))
 
-(defmethod parse-datetime-str
-  java.time.LocalDateTime
+(defmethod parse-datetime-str java.time.LocalDateTime
   [_ date-str]
   (java.time.LocalDateTime/parse date-str))
 
-(defmethod parse-datetime-str
-  java.time.YearMonth
+(defmethod parse-datetime-str java.time.YearMonth
   [_ date-str]
   (java.time.YearMonth/parse date-str))
 
-(defmethod parse-datetime-str
-  java.time.Year
+(defmethod parse-datetime-str java.time.Year
   [_ date-str]
   (java.time.Year/parse date-str))
 

--- a/test/operations_test.clj
+++ b/test/operations_test.clj
@@ -17,26 +17,25 @@
                     (partition 2 (interleave (columns dsa) (columns dsb))))]
     (and colnames-equal cols-equal)))
 
-(deftest slice-by-date
-  (is (ds-equal? (dataset {:A [(t/date "1970-01-09") (t/date "1970-01-10")]
-                           :B [8 9]})
-                 (-> (dataset {:A (plus-temporal-amount (t/date "1970-01-01") (range 10) :days)
-                               :B (range 10)})
-                     (index-by :A)
-                     (ops/slice-by-date "1970-01-09" "1970-01-10")))))
-
-(deftest slice-by-year
-  (is (ds-equal? (dataset {:A [(t/year "1979") (t/year "1980")]
-                           :B [9 10]})
-                 (-> (dataset {:A (plus-temporal-amount (t/year 1970) (range 11) :years)
-                               :B (range 11)})
-                     (index-by :A)
-                     (ops/slice-by-year "1979" "1980")))))
-
-(deftest slice-by-datetime
+(deftest slice
+  ;; local-date-time
   (is (ds-equal? (dataset {:A [(t/date-time "1970-01-01T09:00") (t/date-time "1970-01-01T10:00")]
                            :B [9 10]})
                  (-> (dataset {:A (plus-temporal-amount (t/date-time "1970-01-01T00:00") (range 11) :hours)
                                :B (range 11)})
                      (index-by :A)
-                     (ops/slice-by-datetime "1970-01-01T09:00" "1979-01-01T10:00")))))
+                     (ops/slice "1970-01-01T09:00" "1979-01-01T10:00"))))
+  ;; year
+  (is (ds-equal? (dataset {:A [(t/year "1979") (t/year "1980")]
+                           :B [9 10]})
+                 (-> (dataset {:A (plus-temporal-amount (t/year 1970) (range 11) :years)
+                               :B (range 11)})
+                     (index-by :A)
+                     (ops/slice "1979" "1980"))))
+  ;; local-date
+  (is (ds-equal? (dataset {:A [(t/date "1970-01-09") (t/date "1970-01-10")]
+                           :B [8 9]})
+                 (-> (dataset {:A (plus-temporal-amount (t/date "1970-01-01") (range 10) :days)
+                               :B (range 10)})
+                     (index-by :A)
+                     (ops/slice "1970-01-09" "1970-01-10")))))

--- a/test/operations_test.clj
+++ b/test/operations_test.clj
@@ -18,6 +18,16 @@
     (and colnames-equal cols-equal)))
 
 (deftest slice
+  ;; zoned-date-time
+  (is (ds-equal? (dataset {:A [#time/zoned-date-time "1970-01-01T09:00Z[UTC]"
+                               #time/zoned-date-time "1970-01-01T10:00Z[UTC]"]
+                           :B [9 10]})
+                 (-> (dataset {:A (plus-temporal-amount
+                                   #time/zoned-date-time "1970-01-01T00:00Z[UTC]"
+                                   (range 11) :hours)
+                               :B (range 11)})
+                     (index-by :A)
+                     (ops/slice "1970-01-01T09:00Z[UTC]" "1979-01-01T10:00Z[UTC]"))))
   ;; local-date-time
   (is (ds-equal? (dataset {:A [(t/date-time "1970-01-01T09:00") (t/date-time "1970-01-01T10:00")]
                            :B [9 10]})

--- a/test/operations_test.clj
+++ b/test/operations_test.clj
@@ -16,17 +16,16 @@
                     (partition 2 (interleave (columns dsa) (columns dsb))))]
     (and colnames-equal cols-equal)))
 
+
 (deftest slice
-  ;; zoned-date-time
-  (is (ds-equal? (dataset {:A [#time/zoned-date-time "1970-01-01T09:00Z[UTC]"
-                               #time/zoned-date-time "1970-01-01T10:00Z[UTC]"]
+  ;; instant
+  (is (ds-equal? (dataset {:A [#time/instant "1970-01-01T09:00:00.000Z"
+                               #time/instant "1970-01-01T10:00:00.000Z"]
                            :B [9 10]})
-                 (-> (dataset {:A (plus-temporal-amount
-                                   #time/zoned-date-time "1970-01-01T00:00Z[UTC]"
-                                   (range 11) :hours)
+                 (-> (dataset {:A (plus-temporal-amount #time/instant "1970-01-01T00:00:00.000Z" (range 11) :hours)
                                :B (range 11)})
                      (index-by :A)
-                     (ops/slice "1970-01-01T09:00Z[UTC]" "1979-01-01T10:00Z[UTC]"))))
+                     (ops/slice "1970-01-01T09:00:00.000Z" "1970-01-01T10:00:00.000Z"))))
   ;; local-date-time
   (is (ds-equal? (dataset {:A [#time/date-time "1970-01-01T09:00"
                                #time/date-time "1970-01-01T10:00"]
@@ -42,6 +41,13 @@
                                :B (range 11)})
                      (index-by :A)
                      (ops/slice "1979" "1980"))))
+  ;; year-month
+  (is (ds-equal? (dataset {:A [#time/year-month "1979-01" #time/year-month "1980-01"]
+                           :B [9 10]})
+                 (-> (dataset {:A (plus-temporal-amount #time/year-month "1970-01" (range 11) :years)
+                               :B (range 11)})
+                     (index-by :A)
+                     (ops/slice "1979-01" "1980-01"))))
   ;; local-date
   (is (ds-equal? (dataset {:A [#time/date "1970-01-09" #time/date "1970-01-10"]
                            :B [8 9]})

--- a/test/operations_test.clj
+++ b/test/operations_test.clj
@@ -3,7 +3,7 @@
             [tablecloth.time.index :refer [index-by]]
             [tablecloth.time.operations :as ops]
             [tech.v3.datatype.datetime :refer [plus-temporal-amount]]
-            [clojure.test :refer [deftest is]]))
+            [clojure.test :refer [deftest is are]]))
 
 ;; TODO Consider switch tests to use midje: https://github.com/marick/Midje
 
@@ -16,43 +16,55 @@
                     (partition 2 (interleave (columns dsa) (columns dsb))))]
     (and colnames-equal cols-equal)))
 
+(deftest slice-by-instant
+  (are [_ arg-map] (= (dataset {:A [#time/instant "1970-01-01T09:00:00.000Z"
+                                    #time/instant "1970-01-01T10:00:00.000Z"]
+                                :B [9 10]})
+                      (-> (dataset {:A (plus-temporal-amount #time/instant "1970-01-01T00:00:00.000Z" (range 11) :hours)
+                                    :B (range 11)})
+                          (index-by :A)
+                          (ops/slice (:to arg-map) (:from arg-map))))
+    _ {:to "1970-01-01T09:00:00.000Z" :from "1970-01-01T10:00:00.000Z"}
+    _ {:to #time/instant "1970-01-01T09:00:00.000Z" :from #time/instant "1970-01-01T10:00:00.000Z"}))
 
-(deftest slice
-  ;; instant
-  (is (ds-equal? (dataset {:A [#time/instant "1970-01-01T09:00:00.000Z"
-                               #time/instant "1970-01-01T10:00:00.000Z"]
-                           :B [9 10]})
-                 (-> (dataset {:A (plus-temporal-amount #time/instant "1970-01-01T00:00:00.000Z" (range 11) :hours)
-                               :B (range 11)})
-                     (index-by :A)
-                     (ops/slice "1970-01-01T09:00:00.000Z" "1970-01-01T10:00:00.000Z"))))
-  ;; local-date-time
-  (is (ds-equal? (dataset {:A [#time/date-time "1970-01-01T09:00"
-                               #time/date-time "1970-01-01T10:00"]
-                           :B [9 10]})
-                 (-> (dataset {:A (plus-temporal-amount (t/date-time "1970-01-01T00:00") (range 11) :hours)
-                               :B (range 11)})
-                     (index-by :A)
-                     (ops/slice "1970-01-01T09:00" "1979-01-01T10:00"))))
-  ;; year
-  (is (ds-equal? (dataset {:A [#time/year "1979" #time/year "1980"]
-                           :B [9 10]})
-                 (-> (dataset {:A (plus-temporal-amount #time/year "1970" (range 11) :years)
-                               :B (range 11)})
-                     (index-by :A)
-                     (ops/slice "1979" "1980"))))
-  ;; year-month
-  (is (ds-equal? (dataset {:A [#time/year-month "1979-01" #time/year-month "1980-01"]
-                           :B [9 10]})
-                 (-> (dataset {:A (plus-temporal-amount #time/year-month "1970-01" (range 11) :years)
-                               :B (range 11)})
-                     (index-by :A)
-                     (ops/slice "1979-01" "1980-01"))))
-  ;; local-date
-  (is (ds-equal? (dataset {:A [#time/date "1970-01-09" #time/date "1970-01-10"]
-                           :B [8 9]})
-                 (-> (dataset {:A (plus-temporal-amount #time/date "1970-01-01" (range 10) :days)
-                               :B (range 10)})
-                     (index-by :A)
-                     (ops/slice "1970-01-09" "1970-01-10")))))
+(deftest slice-by-local-datetime
+  (are [_ arg-map] (= (dataset {:A [#time/date-time "1970-01-01T09:00"
+                                    #time/date-time "1970-01-01T10:00"]
+                                :B [9 10]})
+                      (-> (dataset {:A (plus-temporal-amount #time/date-time "1900-01-01T00:00" (range 11) :hours)
+                                    :B (range 11)})
+                          (index-by :A)
+                          (ops/slice (:to arg-map) (:from arg-map))))
+    _ {:to "1970-01-01T09:00" :from "1970-01-01T10:00:00"}
+    _ {:to #time/date-time "1970-01-01T09:00" :from #time/date-time "1970-01-01T10:00"}))
+
+(deftest slice-by-year
+  (are [_ arg-map] (= (dataset {:A [#time/year "1979" #time/year "1980"]
+                                :B [9 10]})
+                      (-> (dataset {:A (plus-temporal-amount #time/year "1970" (range 11) :years)
+                                    :B (range 11)})
+                          (index-by :A)
+                          (ops/slice (:to arg-map) (:from arg-map))))
+    _ {:to "1979" :from "1980"}
+    _ {:to #time/year "1979" :from #time/year "1980"}))
+
+(deftest slice-by-year-month
+  (are [_ arg-map] (= (dataset {:A [#time/year-month "1979-01" #time/year-month "1980-01"]
+                                :B [9 10]})
+                      (-> (dataset {:A (plus-temporal-amount #time/year-month "1970-01" (range 11) :years)
+                                    :B (range 11)})
+                          (index-by :A)
+                          (ops/slice (:to arg-map) (:from arg-map))))
+    _ {:to "1979-01" :from "1980-01"}
+    _ {:to #time/year-month "1979-01" :from #time/year-month "1980-01"}))
+
+(deftest slice-by-local-date
+  (are [_ arg-map] (= (dataset {:A [#time/date "1970-01-09" #time/date "1970-01-10"]
+                                :B [9 10]})
+                      (-> (dataset {:A (plus-temporal-amount #time/date "1970-01-01" (range 11) :years)
+                                    :B (range 11)})
+                          (index-by :A)
+                          (ops/slice (:to arg-map) (:from arg-map))))
+    _ {:to "1979-01-01" :from "1980-01-01"}
+    _ {:to #time/date "1979-01-01" :from #time/date "1980-01-01"}))
 

--- a/test/operations_test.clj
+++ b/test/operations_test.clj
@@ -3,7 +3,6 @@
             [tablecloth.time.index :refer [index-by]]
             [tablecloth.time.operations :as ops]
             [tech.v3.datatype.datetime :refer [plus-temporal-amount]]
-            [tick.alpha.api :as t]
             [clojure.test :refer [deftest is]]))
 
 ;; TODO Consider switch tests to use midje: https://github.com/marick/Midje
@@ -29,23 +28,25 @@
                      (index-by :A)
                      (ops/slice "1970-01-01T09:00Z[UTC]" "1979-01-01T10:00Z[UTC]"))))
   ;; local-date-time
-  (is (ds-equal? (dataset {:A [(t/date-time "1970-01-01T09:00") (t/date-time "1970-01-01T10:00")]
+  (is (ds-equal? (dataset {:A [#time/date-time "1970-01-01T09:00"
+                               #time/date-time "1970-01-01T10:00"]
                            :B [9 10]})
                  (-> (dataset {:A (plus-temporal-amount (t/date-time "1970-01-01T00:00") (range 11) :hours)
                                :B (range 11)})
                      (index-by :A)
                      (ops/slice "1970-01-01T09:00" "1979-01-01T10:00"))))
   ;; year
-  (is (ds-equal? (dataset {:A [(t/year "1979") (t/year "1980")]
+  (is (ds-equal? (dataset {:A [#time/year "1979" #time/year "1980"]
                            :B [9 10]})
-                 (-> (dataset {:A (plus-temporal-amount (t/year 1970) (range 11) :years)
+                 (-> (dataset {:A (plus-temporal-amount #time/year "1970" (range 11) :years)
                                :B (range 11)})
                      (index-by :A)
                      (ops/slice "1979" "1980"))))
   ;; local-date
-  (is (ds-equal? (dataset {:A [(t/date "1970-01-09") (t/date "1970-01-10")]
+  (is (ds-equal? (dataset {:A [#time/date "1970-01-09" #time/date "1970-01-10"]
                            :B [8 9]})
-                 (-> (dataset {:A (plus-temporal-amount (t/date "1970-01-01") (range 10) :days)
+                 (-> (dataset {:A (plus-temporal-amount #time/date "1970-01-01" (range 10) :days)
                                :B (range 10)})
                      (index-by :A)
                      (ops/slice "1970-01-09" "1970-01-10")))))
+


### PR DESCRIPTION
### Goal / Purpose

Simplify the slicing API so that a user does not have to call a specific method (e.g. `slice-by-date`) that matches the time unit they are working with on the index. This PR builds on #2. 

### Solution

The approach I took here works with the constraint that we've so far been sticking to, namely: that the user must be responsible for knowing that the unit that they wish to slice by matches the unit of the indexed column(s). 

This constraint comes into play  in this PR in relation to how we parse the datetime strings that the users provide to the `slice` method. In order to parse these strings we assume that their format should conform to that expected by the parse method of the time unit class of the index's keys. Specifically, we grab the class type of the first key of the index, and then use that type along with Clojure's multimethods to parse the string using the right java.time unit's parse method.

So now we can do something like this:

```clj
(-> data-by-year-month
    (index-by :year-month) ;; assuming the :year-month is a column with java.time.YearMonth date items
    (ops/slice "1949-01" "1949-03"))
```
While the following would fail:
```clj
(-> data-by-year-month
    (index-by :year-month)
    (ops/slice "1949-01-01" "1949-03-01"))
```

The PR also adds a few other things:
* It makes it possible for a user to pass a time-literal (e.g. `#time/year "2015"`) to the slice function;
* it adds a docstring to the `slice` method; and
* it adds some error handling for cases where the `from` or `to` key does not match the time unit of the index.

### Work Remaining / Open Questions

Some pieces that may need work in the future:
* Is there a better way to handle the need for polymorphism around parsing datetime strings?
