### PR TITLE
Reorganize namespaces to mimic tablecloth's style of providing an api

### DIFF
--- a/src/tablecloth/time/api.clj
+++ b/src/tablecloth/time/api.clj
@@ -1,0 +1,5 @@
+(ns tablecloth.time.api
+  (:require [tech.v3.datatype.export-symbols :as exporter]))
+
+(exporter/export-symbols tablecloth.time.api.slice
+                         slice)

--- a/src/tablecloth/time/api/slice.clj
+++ b/src/tablecloth/time/api/slice.clj
@@ -1,4 +1,4 @@
-(ns tablecloth.time.operations
+(ns tablecloth.time.api.slice
   (:import java.time.format.DateTimeParseException)
   (:require [tablecloth.time.index :refer [get-index-type slice-index]]
             [tablecloth.api :as tablecloth]

--- a/test/slice_test.clj
+++ b/test/slice_test.clj
@@ -1,7 +1,7 @@
 (ns tablecloth.time.operations-test
   (:require [tablecloth.api :refer [dataset columns column-names]]
             [tablecloth.time.index :refer [index-by]]
-            [tablecloth.time.operations :as ops]
+            [tablecloth.time.api :refer [slice]]
             [tech.v3.datatype.datetime :refer [plus-temporal-amount]]
             [clojure.test :refer [deftest is are]]))
 
@@ -23,7 +23,7 @@
                       (-> (dataset {:A (plus-temporal-amount #time/instant "1970-01-01T00:00:00.000Z" (range 11) :hours)
                                     :B (range 11)})
                           (index-by :A)
-                          (ops/slice (:to arg-map) (:from arg-map))))
+                          (slice (:to arg-map) (:from arg-map))))
     _ {:to "1970-01-01T09:00:00.000Z" :from "1970-01-01T10:00:00.000Z"}
     _ {:to #time/instant "1970-01-01T09:00:00.000Z" :from #time/instant "1970-01-01T10:00:00.000Z"}))
 
@@ -34,7 +34,7 @@
                       (-> (dataset {:A (plus-temporal-amount #time/date-time "1900-01-01T00:00" (range 11) :hours)
                                     :B (range 11)})
                           (index-by :A)
-                          (ops/slice (:to arg-map) (:from arg-map))))
+                          (slice (:to arg-map) (:from arg-map))))
     _ {:to "1970-01-01T09:00" :from "1970-01-01T10:00:00"}
     _ {:to #time/date-time "1970-01-01T09:00" :from #time/date-time "1970-01-01T10:00"}))
 
@@ -44,7 +44,7 @@
                       (-> (dataset {:A (plus-temporal-amount #time/year "1970" (range 11) :years)
                                     :B (range 11)})
                           (index-by :A)
-                          (ops/slice (:to arg-map) (:from arg-map))))
+                          (slice (:to arg-map) (:from arg-map))))
     _ {:to "1979" :from "1980"}
     _ {:to #time/year "1979" :from #time/year "1980"}))
 
@@ -54,7 +54,7 @@
                       (-> (dataset {:A (plus-temporal-amount #time/year-month "1970-01" (range 11) :years)
                                     :B (range 11)})
                           (index-by :A)
-                          (ops/slice (:to arg-map) (:from arg-map))))
+                          (slice (:to arg-map) (:from arg-map))))
     _ {:to "1979-01" :from "1980-01"}
     _ {:to #time/year-month "1979-01" :from #time/year-month "1980-01"}))
 
@@ -64,7 +64,7 @@
                       (-> (dataset {:A (plus-temporal-amount #time/date "1970-01-01" (range 11) :years)
                                     :B (range 11)})
                           (index-by :A)
-                          (ops/slice (:to arg-map) (:from arg-map))))
+                          (slice (:to arg-map) (:from arg-map))))
     _ {:to "1979-01-01" :from "1980-01-01"}
     _ {:to #time/date "1979-01-01" :from #time/date "1980-01-01"}))
 


### PR DESCRIPTION
### Goal/Purpose

Briefly discussed in passing with @daslu during last weeks session: it may be a good idea to mimick scicloj/tablecloth's namespace organization. The point being that we hide the implementation and expose only the API that we want. 

Tablecloth does this by:
1. Putting the implementation files in a directory called [`api`](https://github.com/scicloj/tablecloth/blob/master/src/tablecloth/api). Within the directory functions are organized sensibly by areas of operation, e.g. column operations are in a file called [`api/columns.clj`.](https://github.com/scicloj/tablecloth/blob/master/src/tablecloth/api/columns.clj). 
2. Exporting only those functions from the namespaces in the `/api` directory files using an exporter function taken from `tech.v3.datatype` in a single file [`api.clj`](https://github.com/scicloj/tablecloth/blob/master/src/tablecloth/api.clj) in the root namespace.

That way when you do `(require 'tablecloth.api)`, you get just the symbols exported by the `api.clj`. 

### Implementation/Solution

This PR mimics the practice described above, applying it to the slice function that we've written. 

### How to test

The tests in `test/slice_test.clj` should still run without error. Note that they import the `slice` function in the new way in the require at the top of the file.