### PR TITLE
updating dependencies, moving dev-related dependencies under dev profile

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -3,10 +3,9 @@
   :url "http://example.com/FIXME"
   :license {:name "The MIT Licence"
             :url "https://opensource.org/licenses/MIT"}
-  :dependencies [[org.clojure/clojure "1.10.1"]
-                 [scicloj/tablecloth "5.00-beta-21"]
-                 [tick "0.4.27-alpha"]
-                 [scicloj/notespace "3-alpha3-SNAPSHOT"]
-                 [aerial.hanami "0.12.4"]]
-  ;; :repl-options {:init-ns tablecloth.time}
-  )
+  :dependencies [[org.clojure/clojure "1.10.2"]
+                 [scicloj/tablecloth "5.00-beta-29.1"]
+                 [tick "0.4.27-alpha"]]
+  :profiles {:dev {:dependencies [[scicloj/notespace "3-beta3"]
+                                  [aerial.hanami "0.12.4"]]}})
+


### PR DESCRIPTION
Notespace and Hanami should not be considered part of the library and pulled by projects using it.
Thus, we need them only in our dev environment. Thus, we can have them at the `:dev` profile rather than as actual dependencies.