### PR TITLE
Support slice by integers

### DIFF
--- a/src/tablecloth/time/api/slice.clj
+++ b/src/tablecloth/time/api/slice.clj
@@ -76,13 +76,15 @@
                            (str (format msg-str arg-symbol time-unit) (.getMessage err))))
          time-unit (get-index-type dataset)
          from-key (cond
-                    (instance? java.time.temporal.Temporal from) from
+                    (or (int? from)
+                        (instance? java.time.temporal.Temporal from)) from
                     :else (try
                             (parse-datetime-str time-unit from)
                             (catch DateTimeParseException err
                               (throw (Exception. ^java.lang.String (build-err-msg err "from" time-unit))))))
          to-key (cond
-                  (instance? java.time.temporal.Temporal to) to
+                  (or (int? from)
+                      (instance? java.time.temporal.Temporal to)) to
                   :else (try
                           (parse-datetime-str time-unit to)
                           (catch DateTimeParseException err
@@ -93,4 +95,3 @@
        (not= time-unit (class to-key))
        (throw (Exception. (format "Time unit of `to` does not match index time unit: %s" time-unit)))
        :else (slice-index dataset from-key to-key options)))))
-

--- a/test/tablecloth/time/api/slice_test.clj
+++ b/test/tablecloth/time/api/slice_test.clj
@@ -7,15 +7,6 @@
 
 ;; TODO Consider switch tests to use midje: https://github.com/marick/Midje
 
-;; Temporary until = fixed for datasets in tech.ml
-(defn ds-equal? [dsa dsb]
-  (let [colnames-equal (= (column-names dsa)
-                          (column-names dsb))
-        cols-equal (every?
-                    #(= (first %) (second %))
-                    (partition 2 (interleave (columns dsa) (columns dsb))))]
-    (and colnames-equal cols-equal)))
-
 (deftest slice-by-int
   (is (= (dataset {:A [2 3]
                    :B [5 6]})
@@ -39,7 +30,7 @@
   (are [_ arg-map] (= (dataset {:A [#time/date-time "1970-01-01T09:00"
                                     #time/date-time "1970-01-01T10:00"]
                                 :B [9 10]})
-                      (-> (dataset {:A (plus-temporal-amount #time/date-time "1900-01-01T00:00" (range 11) :hours)
+                      (-> (dataset {:A (plus-temporal-amount #time/date-time "1970-01-01T00:00" (range 11) :hours)
                                     :B (range 11)})
                           (index-by :A)
                           (slice (:to arg-map) (:from arg-map))))
@@ -48,9 +39,11 @@
 
 (deftest slice-by-year
   (are [_ arg-map] (= (dataset {:A [#time/year "1979" #time/year "1980"]
-                                :B [9 10]})
-                      (-> (dataset {:A (plus-temporal-amount #time/year "1970" (range 11) :years)
-                                    :B (range 11)})
+                                :B [4 5]})
+                      (-> (dataset {:A [#time/year "1975" #time/year "1976"
+                                        #time/year "1977" #time/year "1978"
+                                        #time/year "1979" #time/year "1980"]
+                                    :B (range 6)})
                           (index-by :A)
                           (slice (:to arg-map) (:from arg-map))))
     _ {:to "1979" :from "1980"}
@@ -67,7 +60,7 @@
     _ {:to #time/year-month "1979-01" :from #time/year-month "1980-01"}))
 
 (deftest slice-by-local-date
-  (are [_ arg-map] (= (dataset {:A [#time/date "1970-01-09" #time/date "1970-01-10"]
+  (are [_ arg-map] (= (dataset {:A [#time/date "1979-01-01" #time/date "1980-01-01"]
                                 :B [9 10]})
                       (-> (dataset {:A (plus-temporal-amount #time/date "1970-01-01" (range 11) :years)
                                     :B (range 11)})

--- a/test/tablecloth/time/api/slice_test.clj
+++ b/test/tablecloth/time/api/slice_test.clj
@@ -16,6 +16,14 @@
                     (partition 2 (interleave (columns dsa) (columns dsb))))]
     (and colnames-equal cols-equal)))
 
+(deftest slice-by-int
+  (is (= (dataset {:A [2 3]
+                   :B [5 6]})
+         (-> (dataset {:A [1 2 3]
+                       :B [4 5 6]})
+             (index-by :A)
+             (slice 2 3)))))
+
 (deftest slice-by-instant
   (are [_ arg-map] (= (dataset {:A [#time/instant "1970-01-01T09:00:00.000Z"
                                     #time/instant "1970-01-01T10:00:00.000Z"]

--- a/test/tablecloth/time/api/slice_test.clj
+++ b/test/tablecloth/time/api/slice_test.clj
@@ -2,15 +2,16 @@
   (:require [tablecloth.api :refer [dataset columns column-names]]
             [tablecloth.time.index :refer [index-by]]
             [tablecloth.time.api :refer [slice]]
-            [tech.v3.datatype.datetime :refer [plus-temporal-amount]]
+            [tech.v3.datatype.datetime :refer [long-temporal-field plus-temporal-amount]]
             [clojure.test :refer [deftest is are]]))
 
 ;; TODO Consider switch tests to use midje: https://github.com/marick/Midje
 
-(deftest slice-by-int
+(deftest slice-by-long-temporal-field
   (is (= (dataset {:A [2 3]
                    :B [5 6]})
-         (-> (dataset {:A [1 2 3]
+         (-> (dataset {:A (long-temporal-field :day-of-year
+                                               (plus-temporal-amount #time/date "1970-01-01" (range 3) :days))
                        :B [4 5 6]})
              (index-by :A)
              (slice 2 3)))))


### PR DESCRIPTION
## Problem

There are some situations in which we may want to slice time in terms of an integer (or long). For example, dtype-next's date time has a function `long-temporal-field` that converts datetime datatypes to longs.

## Solution

Just check to see if the `to/from` keys are ints, and if so pass the key through without any conversion.

## How to test

1. Check the logic of the new test added [here]().
2. Run the test.

## Also in this PR

1. Some of the tests were broken because I'd not been using `ds-equal` (silly oversight). 
2. I fixed the tests and removed `ds-equal` because dataset equality now seems to have been fixed.