### PR TITLE
Replace eastwood with clj-kondo

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -1,0 +1,3 @@
+{:linters
+ {:unresolved-var {:exclude [tablecloth.api]} ;; set b/c was getting unresolved-vars even when using :refer in ns form
+  }}

--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -1,3 +1,4 @@
 {:linters
- {:unresolved-var {:level :off} ;; set b/c seems to be triggered by fns exported with tech.datatype.export-symbols/export-symbols fn.
+ {:unresolved-var {:level :info} ;; set b/c seems to be triggered by fns exported with tech.datatype.export-symbols/export-symbols fn.
+  :unresolved-symbol {:level :info}
   }}

--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -1,3 +1,3 @@
 {:linters
- {:unresolved-var {:exclude [tablecloth.api]} ;; set b/c was getting unresolved-vars even when using :refer in ns form
+ {:unresolved-var {:level :off} ;; set b/c seems to be triggered by fns exported with tech.datatype.export-symbols/export-symbols fn.
   }}

--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,4 @@ pom.xml.asc
 /.prepl-port
 .hgignore
 .hg/
-.eastwood
+.clj-kondo

--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,4 @@ pom.xml.asc
 /.prepl-port
 .hgignore
 .hg/
-.clj-kondo
+.clj-kondo/.cache

--- a/project.clj
+++ b/project.clj
@@ -8,10 +8,15 @@
                  [tick "0.4.27-alpha"]
                  [scicloj/notespace "3-alpha3-SNAPSHOT"]
                  [aerial.hanami "0.12.4"]]
-  :profiles {:dev {:dependencies [[midje/midje "1.9.10" :exclusions [org.clojure/clojure]]]
-                   :plugins [[lein-cljfmt "0.7.0"]
-                             [jonase/eastwood "0.3.14"]
-                             [lein-midje "3.2.1"]]
-                   :aliases {"lint" ["do"
-                                     ["cljfmt" "check"]
-                                     ["eastwood" "{:source-paths [\"src\"]}"]]}}})
+  :profiles
+  {:dev {:dependencies [[scicloj/notespace "3-beta3"]
+                        [aerial.hanami "0.12.4"]
+                        [clj-kondo "2021.03.03"]
+                        [midje/midje "1.9.10"
+                          :exclusions [org.clojure/clojure]]]
+         :plugins [[lein-cljfmt "0.7.0"]
+                   [lein-midje "3.2.1"]]
+         :aliases {"clj-kondo" ["run" "-m" "clj-kondo.main"]
+                   "lint" ["do"
+                           ["cljfmt" "check"]
+                           ["run" "-m" "clj-kondo.main" "--lint" "src"]]}}})

--- a/project.clj
+++ b/project.clj
@@ -19,4 +19,4 @@
          :aliases {"clj-kondo" ["run" "-m" "clj-kondo.main"]
                    "lint" ["do"
                            ["cljfmt" "check"]
-                           ["run" "-m" "clj-kondo.main" "--lint" "src"]]}}})
+                           ["run" "-m" "clj-kondo.main" "--lint" "src:test"]]}}})

--- a/src/tablecloth/time/api.clj
+++ b/src/tablecloth/time/api.clj
@@ -1,5 +1,4 @@
 (ns tablecloth.time.api
-  ;; {:clj-kondo/config '{:linters {:unresolved-symbol {:level :off}}}}
   (:require [tech.v3.datatype.export-symbols :as exporter]))
 
 (exporter/export-symbols tablecloth.time.api.slice

--- a/src/tablecloth/time/api.clj
+++ b/src/tablecloth/time/api.clj
@@ -1,5 +1,5 @@
 (ns tablecloth.time.api
-  {:clj-kondo/config '{:linters {:unresolved-symbol {:level :off}}}}
+  ;; {:clj-kondo/config '{:linters {:unresolved-symbol {:level :off}}}}
   (:require [tech.v3.datatype.export-symbols :as exporter]))
 
 (exporter/export-symbols tablecloth.time.api.slice

--- a/src/tablecloth/time/api.clj
+++ b/src/tablecloth/time/api.clj
@@ -1,4 +1,5 @@
 (ns tablecloth.time.api
+  {:clj-kondo/config '{:linters {:unresolved-symbol {:level :off}}}}
   (:require [tech.v3.datatype.export-symbols :as exporter]))
 
 (exporter/export-symbols tablecloth.time.api.slice

--- a/src/tablecloth/time/api/slice.clj
+++ b/src/tablecloth/time/api/slice.clj
@@ -1,9 +1,6 @@
 (ns tablecloth.time.api.slice
   (:import java.time.format.DateTimeParseException)
-  (:require [tablecloth.time.index :refer [get-index-type slice-index]]
-            [tablecloth.api :as tablecloth]
-            [tech.v3.datatype.errors :as errors]
-            [tick.alpha.api :as t]))
+  (:require [tablecloth.time.index :refer [get-index-type slice-index]]))
 
 (set! *warn-on-reflection* true)
 
@@ -69,8 +66,7 @@
   | 1973 |  3 |
   "
   ([dataset from to] (slice dataset from to nil))
-  ([dataset from to {:keys [result-type]
-                     :or {result-type :as-dataset} :as options}]
+  ([dataset from to options]
    (let [build-err-msg (fn [^java.lang.Exception err arg-symbol time-unit]
                          (let [msg-str "Unable to parse `%s` date string. Its format may not match the expected format for the index time unit: %s. "]
                            (str (format msg-str arg-symbol time-unit) (.getMessage err))))

--- a/src/tablecloth/time/index.clj
+++ b/src/tablecloth/time/index.clj
@@ -30,8 +30,7 @@
   - result-type - return results as dataset (`:as-dataset`, default) or a row of indexes (`:as-indexes`). "
   ([dataset from to] (slice-index dataset from to nil))
   ([dataset from to {:keys [result-type]
-                     :or {result-type :as-dataset}
-                     :as options}]
+                     :or {result-type :as-dataset}}]
    (let [^TreeMap index (get-index-meta dataset)
          row-numbers (if (not index)
                        (throw (Exception. "Dataset has no index specified."))

--- a/src/tablecloth/time/index.clj
+++ b/src/tablecloth/time/index.clj
@@ -1,6 +1,6 @@
 (ns tablecloth.time.index
   (:import java.util.TreeMap)
-  (:require [tablecloth.api :as tablecloth]))
+  (:require [tablecloth.api :refer [select-rows rows]]))
 
 (set! *warn-on-reflection* true)
 
@@ -15,7 +15,7 @@
 (defn make-index
   "Returns an index for `dataset` based on the specified `index-column-key`."
   [dataset index-column-key]
-  (let [row-maps (-> dataset (tablecloth/rows :as-maps))
+  (let [row-maps (-> dataset (rows :as-maps))
         idx-map (->> row-maps
                      (map-indexed (fn [row-number row-map]
                                     [(index-column-key row-map) row-number]))
@@ -37,7 +37,7 @@
                        (-> index (.subMap from true to true) (.values)))]
      (condp = result-type
        :as-indexes row-numbers
-       (tablecloth/select-rows dataset row-numbers)))))
+       (select-rows dataset row-numbers)))))
 
 (defn index-by
   "Returns a dataset with an index attached as metadata."

--- a/test/tablecloth/time/api/slice_test.clj
+++ b/test/tablecloth/time/api/slice_test.clj
@@ -1,9 +1,10 @@
 (ns tablecloth.time.api.slice-test
-  (:require [tablecloth.api :refer [dataset columns column-names]]
+  (:require [tablecloth.api :refer [dataset]]
             [tablecloth.time.index :refer [index-by]]
             [tablecloth.time.api :refer [slice]]
             [tech.v3.datatype.datetime :refer [long-temporal-field plus-temporal-amount]]
-            [clojure.test :refer [deftest is are]]))
+            [clojure.test :refer [deftest is are]]
+            [time-literals.data-readers]))
 
 ;; TODO Consider switch tests to use midje: https://github.com/marick/Midje
 


### PR DESCRIPTION
## Goal

Replace the linter eastwood with a more popular and polished linter: `clj-kondo`: https://github.com/clj-kondo/clj-kondo

## Also in this PR

Miscellaneous changes to get the linters to pass.