### PR TITLE
Use lein-deps-tools for hybrid leinigen/tools.deps project config

### DIFF
--- a/.github/workflows/run-linters.yml
+++ b/.github/workflows/run-linters.yml
@@ -6,7 +6,7 @@ on:
       - main
 
 jobs:
-  build:
+  run-linters:
 
     runs-on: ubuntu-latest
 
@@ -22,3 +22,9 @@ jobs:
 
     - name: Install dependencies
       run: lein deps
+
+    - name: Leinigen version
+      run: lein -v
+
+    - name: Run linters
+      run: lein lint

--- a/.github/workflows/run-linters.yml
+++ b/.github/workflows/run-linters.yml
@@ -18,3 +18,4 @@ jobs:
       uses: DeLaGuardo/setup-clojure@3.2
       with:
         cli: latest
+	lein: latest

--- a/.github/workflows/run-linters.yml
+++ b/.github/workflows/run-linters.yml
@@ -20,5 +20,5 @@ jobs:
         cli: latest
         lein: latest
 
-    - name: Leinigen version
-      run: lein -v
+    - name: Install dependencies
+      run: lein deps

--- a/.github/workflows/run-linters.yml
+++ b/.github/workflows/run-linters.yml
@@ -17,7 +17,5 @@ jobs:
     - name: Install clojure tools
       uses: DeLaGuardo/setup-clojure@3.2
       with:
-        # Install just one or all simultaneously
-        cli: 1.10.1.693 # Clojure CLI based on tools.deps
-        lein: 2.9.1     # or use 'latest' to always provision latest version of leiningen
-        boot: 2.8.3     # or use 'latest' to always provision latest version of boot
+        cli: latest
+        lein: latest

--- a/.github/workflows/run-linters.yml
+++ b/.github/workflows/run-linters.yml
@@ -11,13 +11,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+
     - name: Install clojure tools
-    - uses: DeLaGuardo/setup-clojure@3.2
+      uses: DeLaGuardo/setup-clojure@3.2
       with:
-        cli: 'latest'
-	lein: 'latest'
-    - name: Install dependencies
-    - uses: actions/checkout@v2
-      run: lein deps
-    - name: Run linters
-      run: lein lint
+        cli: "latest"
+	lein: "latest"

--- a/.github/workflows/run-linters.yml
+++ b/.github/workflows/run-linters.yml
@@ -11,13 +11,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
     - name: Install clojure tools
-      uses: DeLaGuardo/setup-clojure@3.2
+    - uses: DeLaGuardo/setup-clojure@3.2
       with:
         cli: 'latest'
 	lein: 'latest'
     - name: Install dependencies
+    - uses: actions/checkout@v2
       run: lein deps
     - name: Run linters
       run: lein lint

--- a/.github/workflows/run-linters.yml
+++ b/.github/workflows/run-linters.yml
@@ -19,3 +19,9 @@ jobs:
       with:
         cli: latest
         lein: latest
+
+   - name: Leinigen version
+     run: lein -v
+
+   - name: Install dependencies
+     run: lein deps

--- a/.github/workflows/run-linters.yml
+++ b/.github/workflows/run-linters.yml
@@ -19,9 +19,5 @@ jobs:
       with:
         cli: latest
         lein: latest
-
    - name: Leinigen version
      run: lein -v
-
-   - name: Install dependencies
-     run: lein deps

--- a/.github/workflows/run-linters.yml
+++ b/.github/workflows/run-linters.yml
@@ -17,5 +17,7 @@ jobs:
     - name: Install clojure tools
       uses: DeLaGuardo/setup-clojure@3.2
       with:
-        cli: latest
-	lein: latest
+	# Install just one or all simultaneously
+	cli: 1.10.1.693 # Clojure CLI based on tools.deps
+	lein: 2.9.1     # or use 'latest' to always provision latest version of leiningen
+	boot: 2.8.3     # or use 'latest' to always provision latest version of boot

--- a/.github/workflows/run-linters.yml
+++ b/.github/workflows/run-linters.yml
@@ -16,3 +16,5 @@ jobs:
 
     - name: Install clojure tools
       uses: DeLaGuardo/setup-clojure@3.2
+      with:
+        cli: latest

--- a/.github/workflows/run-linters.yml
+++ b/.github/workflows/run-linters.yml
@@ -19,5 +19,3 @@ jobs:
       with:
         cli: latest
         lein: latest
-   - name: Leinigen version
-     run: lein -v

--- a/.github/workflows/run-linters.yml
+++ b/.github/workflows/run-linters.yml
@@ -12,6 +12,11 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+    - name: Install clojure tools
+      uses: DeLaGuardo/setup-clojure@3.2
+      with:
+        cli: latest
+	lein: latest
     - name: Install dependencies
       run: lein deps
     - name: Run linters

--- a/.github/workflows/run-linters.yml
+++ b/.github/workflows/run-linters.yml
@@ -15,8 +15,8 @@ jobs:
     - name: Install clojure tools
       uses: DeLaGuardo/setup-clojure@3.2
       with:
-        cli: latest
-	lein: latest
+        cli: 'latest'
+	lein: 'latest'
     - name: Install dependencies
       run: lein deps
     - name: Run linters

--- a/.github/workflows/run-linters.yml
+++ b/.github/workflows/run-linters.yml
@@ -19,3 +19,6 @@ jobs:
       with:
         cli: latest
         lein: latest
+
+    - name: Leinigen version
+      run: lein -v

--- a/.github/workflows/run-linters.yml
+++ b/.github/workflows/run-linters.yml
@@ -16,6 +16,3 @@ jobs:
 
     - name: Install clojure tools
       uses: DeLaGuardo/setup-clojure@3.2
-      with:
-        cli: "latest"
-	lein: "latest"

--- a/.github/workflows/run-linters.yml
+++ b/.github/workflows/run-linters.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Install clojure tools
       uses: DeLaGuardo/setup-clojure@3.2
       with:
-	# Install just one or all simultaneously
-	cli: 1.10.1.693 # Clojure CLI based on tools.deps
-	lein: 2.9.1     # or use 'latest' to always provision latest version of leiningen
-	boot: 2.8.3     # or use 'latest' to always provision latest version of boot
+        # Install just one or all simultaneously
+        cli: 1.10.1.693 # Clojure CLI based on tools.deps
+        lein: 2.9.1     # or use 'latest' to always provision latest version of leiningen
+        boot: 2.8.3     # or use 'latest' to always provision latest version of boot

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -6,13 +6,25 @@ on:
       - main
 
 jobs:
-  build:
+  run-tests:
 
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - name: Install clojure tools
+      uses: DeLaGuardo/setup-clojure@3.2
+      with:
+        cli: latest
+        lein: latest
+
     - name: Install dependencies
       run: lein deps
+
+    - name: Leinigen version
+      run: lein -v
+
     - name: Run tests
       run: lein midje

--- a/deps-dev.edn
+++ b/deps-dev.edn
@@ -1,0 +1,5 @@
+{:deps {scicloj/notespace {:mvn/version "3-beta3"}
+        aerial.hanami     {:mvn/version "0.12.4"}
+        clj-kondo         {:mvn/version "2021.03.03"}
+        midje/midje       {:mvn/version "1.9.10"
+                           :exclusions [org.clojure/clojure]}}}

--- a/deps.edn
+++ b/deps.edn
@@ -1,4 +1,10 @@
-{:deps {org.clojure/clojure         {:mvn/version "1.10.2"}
-        scicloj/tablecloth          {:mvn/version "6.00-beta-7"}
-        tick                        {:mvn/version "0.4.27-alpha"}
-        org.threeten/threeten-extra {:mvn/version "1.5.0"}}}
+{:deps
+ {org.clojure/clojure         {:mvn/version "1.10.2"}
+  scicloj/tablecloth          {:mvn/version "6.00-beta-7"}
+  tick                        {:mvn/version "0.4.27-alpha"}
+  org.threeten/threeten-extra {:mvn/version "1.5.0"}}
+ :aliases
+ {:dev
+  {:extra-deps {clj-kondo         {:mvn/version "2021.03.03"}
+                scicloj/notespace {:mvn/version "3-beta3"}
+                midje/midje       {:mvn/version "1.9.10"}}}}}

--- a/deps.edn
+++ b/deps.edn
@@ -1,0 +1,4 @@
+{:deps {org.clojure/clojure         {:mvn/version "1.10.2"}
+        scicloj/tablecloth          {:mvn/version "6.00-beta-7"}
+        tick                        {:mvn/version "0.4.27-alpha"}
+        org.threeten/threeten-extra {:mvn/version "1.5.0"}}}

--- a/project.clj
+++ b/project.clj
@@ -4,21 +4,17 @@
   :license {:name "The MIT Licence"
             :url "https://opensource.org/licenses/MIT"}
 
-  :dependencies [[org.clojure/clojure "1.10.2"]
-                 [scicloj/tablecloth "5.04"]
-                 [tick "0.4.27-alpha"]
-                 [org.threeten/threeten-extra "1.5.0"]]
+  :plugins [[lein-tools-deps "0.4.5"]]
+  :middleware [lein-tools-deps.plugin/resolve-dependencies-with-deps-edn]
 
-  :profiles
-  {:dev {:dependencies [[scicloj/notespace "3-beta3"]
-                        [aerial.hanami "0.12.4"]
-                        [clj-kondo "2021.03.03"]
-                        [midje/midje "1.9.10"
-                          :exclusions [org.clojure/clojure]]]
-         :plugins [[lein-cljfmt "0.7.0"]
-                   [lein-midje "3.2.1"]]
-         :aliases {"clj-kondo" ["run" "-m" "clj-kondo.main"]
-                   "lint" ["do"
-                           ["cljfmt" "check"]
-                           ["run" "-m" "clj-kondo.main" "--lint" "src:test"]]}}})
+  :lein-tools-deps/config {:config-files [:install :user :project]}
+
+  :profiles {:dev {:lein-tools-deps/config ["deps-dev.edn"]
+                   :plugins [[lein-cljfmt "0.7.0"]
+                             [lein-midje "3.2.1"]]
+                   :aliases {"clj-kondo" ["run" "-m" "clj-kondo.main"]
+                             "lint" ["do"
+                                     ["cljfmt" "check"]
+                                     ["run" "-m" "clj-kondo.main" "--lint" "src:test"]]}}}
+  )
 

--- a/project.clj
+++ b/project.clj
@@ -7,13 +7,14 @@
   :plugins [[lein-tools-deps "0.4.5"]]
   :middleware [lein-tools-deps.plugin/resolve-dependencies-with-deps-edn]
 
-  :lein-tools-deps/config {:config-files [:install :user :project]
-                           :aliases [:dev]}
+  :lein-tools-deps/config {:config-files [:install :user :project]}
 
-  :profiles {:dev {:aliases {"clj-kondo" ["run" "-m" "clj-kondo.main"]
+  :profiles {:dev {:lein-tools-deps/config {:aliases [:dev]}
+                   :aliases {"clj-kondo" ["run" "-m" "clj-kondo.main"]
                              "lint" ["do"
                                      ["cljfmt" "check"]
                                      ["run" "-m" "clj-kondo.main" "--lint" "src:test"]]}
                    :plugins [[lein-midje "3.2.1"]
-                             [lein-cljfmt "0.7.0"]]}})
+                             [lein-cljfmt "0.7.0"]]}}
+  )
 

--- a/project.clj
+++ b/project.clj
@@ -11,7 +11,7 @@
                            :aliases [:dev]}
 
   :profiles {:dev {:aliases {"clj-kondo" ["run" "-m" "clj-kondo.main"]
-                             "lint" [do
+                             "lint" ["do"
                                      ["cljfmt" "check"]
                                      ["run" "-m" "clj-kondo.main" "--lint" "src:test"]]}
                    :plugins [[lein-midje "3.2.1"]

--- a/project.clj
+++ b/project.clj
@@ -15,6 +15,5 @@
                                      ["cljfmt" "check"]
                                      ["run" "-m" "clj-kondo.main" "--lint" "src:test"]]}
                    :plugins [[lein-midje "3.2.1"]
-                             [lein-cljfmt "0.7.0"]]}}
-  )
+                             [lein-cljfmt "0.7.0"]]}})
 

--- a/project.clj
+++ b/project.clj
@@ -7,14 +7,13 @@
   :plugins [[lein-tools-deps "0.4.5"]]
   :middleware [lein-tools-deps.plugin/resolve-dependencies-with-deps-edn]
 
-  :lein-tools-deps/config {:config-files [:install :user :project]}
+  :lein-tools-deps/config {:config-files [:install :user :project]
+                           :aliases [:dev]}
 
-  :profiles {:dev {:lein-tools-deps/config ["deps-dev.edn"]
-                   :plugins [[lein-cljfmt "0.7.0"]
-                             [lein-midje "3.2.1"]]
-                   :aliases {"clj-kondo" ["run" "-m" "clj-kondo.main"]
-                             "lint" ["do"
+  :profiles {:dev {:aliases {"clj-kondo" ["run" "-m" "clj-kondo.main"]
+                             "lint" [do
                                      ["cljfmt" "check"]
-                                     ["run" "-m" "clj-kondo.main" "--lint" "src:test"]]}}}
-  )
+                                     ["run" "-m" "clj-kondo.main" "--lint" "src:test"]]}
+                   :plugins [[lein-midje "3.2.1"]
+                             [lein-cljfmt "0.7.0"]]}})
 

--- a/test/tablecloth/time/validatable_test.clj
+++ b/test/tablecloth/time/validatable_test.clj
@@ -20,6 +20,5 @@
             not))
     (is (-> ds-with-validatable
             (tablecloth/add-or-replace-column :z 9)
-            (validatable/valid? :id1)))))
-
-
+            (validatable/valid? :id1)
+            not))))


### PR DESCRIPTION
## Problem/Goal

We would like to use a hybrid leinigen/tools.deps configuration so that those who want to use clojure tools may do so, and we get some of the other benefits of tools.deps without losing the automation for project building etc that leinigen provides.

## Solution

We can do this with the [lein-tools-deps](https://github.com/RickMoynihan/lein-tools-deps) library. So this PR adds a `deps.edn` file for dependencies and adjusts our `project.clj` to use lein-tools-deps.

One caveat that we may want to be aware of is that lein-tools-deps warns that the tool can make it hard on users where ther are dependency conflicts (see [here](https://github.com/RickMoynihan/lein-tools-deps#do-you-really-want-to-use-this)).

## How to test

1. Run `lein repl`
- [x] Confirm that you can load the repl
2. While in the repl, do `(require '[tablecloth.api :as tabl])`.
- [x] Confirm that this works, i.e. the dependency is present.
3. Exit the repl and run `lein test`
- [x] Confirm that the test run and pass
4. Run `lein lint`
- [x] Confirm that the linters run
5. Now we'll make sure we aren't loading dev dependencies in non-dev mode.  Run this command : `lein with-profile -dev deps :tree | grep midje`. (The `with-profile -dev` disables the dev profile).
- [x] Confirm that you **do not** see any midje dependency in the output.
