### PR TITLE
Fix typo in lint command in cd workflow

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -34,7 +34,7 @@ jobs:
         run: lein -v
 
       - name: Lint!
-        run: lein 
+        run: lein lint
 
   run-tests:
     if: github.event.action == 'closed' && github.event.pull_request.merged == true


### PR DESCRIPTION
### Goal / Problem

Typo in the cd workflow so linting wasn't running.
