### PR TITLE
Sid/datetime convertor functions

### DIFF
--- a/src/tablecloth/time/api.clj
+++ b/src/tablecloth/time/api.clj
@@ -24,4 +24,5 @@
                          ->quarters-end
                          ->years-end
                          ->every
-                         string->time)
+                         string->time
+                         year-quarter->local-date)

--- a/src/tablecloth/time/api/converters.clj
+++ b/src/tablecloth/time/api/converters.clj
@@ -1,5 +1,6 @@
 (ns tablecloth.time.api.converters
   (:import [java.time Year]
+           [java.time.format DateTimeFormatter]
            [org.threeten.extra YearWeek YearQuarter])
   (:require [tech.v3.datatype.datetime :as dtdt]
             [tech.v3.datatype :as dt]
@@ -19,6 +20,11 @@
 
 (defn year->local-date [^Year year]
   (-> year (.atMonthDay (java.time.MonthDay/parse "--01-01"))))
+
+(defn year-quarter->local-date [year-quarter format-pattern]
+  (-> year-quarter
+      (YearQuarter/parse (DateTimeFormatter/ofPattern format-pattern))
+      .atEndOfQuarter))
 
 (defn year->milliseconds-since-epoch [^Year year]
   (-> year year->local-date dtdt/local-date->milliseconds-since-epoch))

--- a/test/tablecloth/time/api/converters_test.clj
+++ b/test/tablecloth/time/api/converters_test.clj
@@ -3,7 +3,7 @@
             [tablecloth.time.api :refer [down-to-nearest ->seconds convert-to
                                          ->minutes ->hours ->days ->weeks-end
                                          ->months-end ->quarters-end ->years-end
-                                         string->time]]))
+                                         string->time year-quarter->local-date]]))
 
 (deftest test-down-to-nearest
   (testing "returns partial fn if datetime not provided"
@@ -52,6 +52,10 @@
 (deftest test->years-end
   (is (= #time/date "1970-12-31"
          (->years-end #time/date "1970-01-01"))))
+
+(deftest test->year-quarter
+  (is (= #time/date "2016-03-31"
+         (year-quarter->local-date "2016 Q1" "yyyy 'Q'q"))))
 
 (deftest test-convert-to
   (is (= #time/date "1970-01-01"


### PR DESCRIPTION
### Goal / Problem

We depend on dtype-next datatypes, including datetime representations for the data in datasets. As the datetime datatype uses integer values for datetimes, we have a gap in modeling higher order granularity in time, such as quarter, month, week, etc.

### Proposed Solution
The approach considered here is to treat the higher order time objects as dates, by setting it to the last date of that time period. 

So, "2020-Q1" is represented as the local date "2020-03-31", as that is the last-date of the quarter. Last date of the period is just a convention that we are adopting.

Similarly, it is easy to see that "2020-Mar" will be "2020-03-31". We leave it to the user to differentiate quarter vs month aspects of a date "2020-03-21".

The key advantage with this approach is that we can leverage all the features of a datetime datatype, including the ability to automatically index on such columns.

### Work remaining

- We need helper functions to translate easily from higher order time data to local date and vice-versa. 
- We need to extend year-quarter to year-month and year-week (as those use cases show up)

### Open Questions

At some point, we need to look for alternatives for the above approach. One such possibility is to deconstruct year-quarter into a  tuple of two integers for year and quarter, with each value as a column in the data set. The indexing will need a multiple column index solution.