### PR TITLE
Make indexing tools simpler

### DIFF
--- a/src/tablecloth/time/api/slice.clj
+++ b/src/tablecloth/time/api/slice.clj
@@ -1,8 +1,6 @@
 (ns tablecloth.time.api.slice
   (:import java.time.format.DateTimeParseException)
-  (:require [tablecloth.time.utils.indexing :refer [index-column-datatype
-                                                    can-identify-index-column?
-                                                    auto-detect-index-column]]
+  (:require [tablecloth.time.utils.indexing :refer [get-index-column-or-error]]
             [tablecloth.time.utils.datatypes :refer [get-datatype time-datatype?]]
             [tablecloth.api :refer [select-rows]]
             [tech.v3.dataset.column :refer [index-structure]]
@@ -84,9 +82,8 @@
    (let [build-err-msg (fn [^java.lang.Exception err arg-symbol time-unit]
                          (let [msg-str "Unable to parse `%s` date string. Its format may not match the expected format for the index time unit: %s. "]
                            (str (format msg-str arg-symbol time-unit) (.getMessage err))))
-         time-unit (if (can-identify-index-column? dataset)
-                     (unpack-datatype (index-column-datatype dataset))
-                     (throw (Exception. "Unable to auto detect time column to serve as index. Please specify the index using `index-by`.")))
+         index-column (get-index-column-or-error dataset)
+         time-unit (unpack-datatype (get-datatype index-column))
          from-key (cond
                     (or (int? from)
                         (time-datatype? (get-datatype from))) from
@@ -106,7 +103,7 @@
        (throw (Exception. (format "Time unit of `from` does not match index time unit: %s" time-unit)))
        (not= time-unit (get-datatype to-key))
        (throw (Exception. (format "Time unit of `to` does not match index time unit: %s" time-unit)))
-       :else (let [index (-> dataset auto-detect-index-column index-structure)
+       :else (let [index (index-structure index-column)
                    slice-indexes (select-from-index index :slice {:from from-key :to to-key})]
                (condp = result-type
                  :as-indexes slice-indexes

--- a/src/tablecloth/time/utils/indexing.clj
+++ b/src/tablecloth/time/utils/indexing.clj
@@ -4,9 +4,6 @@
             [tech.v3.datatype.casting :refer [datatype->object-class]]
             [tech.v3.datatype.packing :refer [unpack-datatype]]))
 
-(def unidentifiable-index-error
-  (Exception. "Unable to auto detect time column to serve as index. Please specify the index using `index-by`."))
-
 (defn time-column? [col]
   (time-datatype? (get-datatype col)))
 


### PR DESCRIPTION
### Goal / Problem

Two different problems here:
* Previously, the code threw the error saying it could not identify the index in the function code, but this error is actually predictable. Anytime we can't find the index we want to tell the user know that that is the problem and let them know to use `index-by` to clarify the confusion. 
* The API for the indexing tools seemed unnecessarily complex.

### Proposed Solution

This PR adds a new function `get-index-column-or-error` that in many cases may be all that we need to import for an index-aware function. This function will return the index column, or if it cannot figure out which one is the time index, it will throw a standard error that asks the user to use `index-by` to specify the index.

I also added a sibling fn `get-index-column-name-or-error`, that may be useful when we only need to know the index column name.

