### PR TITLE
Use string->time in slice to parse strings

### DIFF
--- a/src/tablecloth/time/api/slice.clj
+++ b/src/tablecloth/time/api/slice.clj
@@ -2,47 +2,13 @@
   (:import java.time.format.DateTimeParseException)
   (:require [tablecloth.time.utils.indexing :refer [get-index-column-or-error]]
             [tablecloth.time.utils.datatypes :refer [get-datatype time-datatype?]]
+            [tablecloth.time.api.converters :refer [string->time]]
             [tablecloth.api :refer [select-rows]]
             [tech.v3.dataset.column :refer [index-structure]]
             [tech.v3.dataset.column-index-structure :refer [select-from-index]]
             [tech.v3.datatype.packing :refer [unpack-datatype]]))
 
 (set! *warn-on-reflection* true)
-
-;; These parsing tools should probably become part of our own
-;; parsing fn.
-(defmulti parse-datetime-str
-  (fn [datetime-datatype _] datetime-datatype))
-
-(defmethod parse-datetime-str :instant
-  [_ date-str]
-  (java.time.Instant/parse date-str))
-
-(defmethod parse-datetime-str :local-date
-  [_ date-str]
-  (java.time.LocalDate/parse date-str))
-
-(defmethod parse-datetime-str :local-date-time
-  [_ date-str]
-  (java.time.LocalDateTime/parse date-str))
-
-;; Leaving these around for when we generalize a parsing fn
-;; Commenting out for now b/c we aren't sure about support for
-;; these other types consdering our use of tech.datatype.datetime
-;; that doesn't support these. See this conversation:
-;; https://clojurians.zulipchat.com/#narrow/stream/236259-tech.2Eml.2Edataset.2Edev/topic/extra.20datetime.20types/near/239699398
-
-;; (defmethod parse-datetime-str java.time.ZonedDateTime
-;;   [_ date-str]
-;;   (java.time.ZonedDateTime/parse date-str))
-
-;; (defmethod parse-datetime-str java.time.YearMonth
-;;   [_ date-str]
-;;   (java.time.YearMonth/parse date-str))
-
-;; (defmethod parse-datetime-str java.time.Year
-;;   [_ date-str]
-;;   (java.time.Year/parse date-str))
 
 (defn slice
   "Returns a subset of dataset's rows (or row indexes) as specified by from and to, inclusively.
@@ -88,14 +54,14 @@
                     (or (int? from)
                         (time-datatype? (get-datatype from))) from
                     :else (try
-                            (parse-datetime-str (unpack-datatype time-unit) from)
+                            (string->time from)
                             (catch DateTimeParseException err
                               (throw (Exception. ^java.lang.String (build-err-msg err "from" time-unit))))))
          to-key (cond
                   (or (int? to)
                       (time-datatype? (get-datatype from))) to
                   :else (try
-                          (parse-datetime-str (unpack-datatype time-unit) to)
+                          (string->time to)
                           (catch DateTimeParseException err
                             (throw (Exception. ^java.lang.String (build-err-msg err "to" time-unit))))))]
      (cond


### PR DESCRIPTION
### Goal / Problem

In #33 , we added our own parse method: `string->time`. We can use this to replace the custom method that we'd temporarily added. 

### Proposed Solution

Solution here is quick, just dropping in the other function. One note is that we no longer need to determine the type of the time unit to do the parsing.
