### PR TITLE
Add time component extractors

### DIFF
--- a/src/tablecloth/time/api.clj
+++ b/src/tablecloth/time/api.clj
@@ -32,3 +32,13 @@
                          ->years-end
                          ->every
                          string->time)
+
+(exporter/export-symbols tablecloth.time.api.time-components
+                         year
+                         dayofyear
+                         month
+                         dayofmonth
+                         dayofweek
+                         hour
+                         minute
+                         secnd)

--- a/src/tablecloth/time/api/converters.clj
+++ b/src/tablecloth/time/api/converters.clj
@@ -1,5 +1,5 @@
 (ns tablecloth.time.api.converters
-  (:import [java.time Year]
+  (:import [java.time Year Month LocalDateTime]
            [org.threeten.extra YearWeek YearQuarter])
   (:require [tech.v3.datatype.datetime :as dtdt]
             [tech.v3.datatype :as dt]
@@ -175,3 +175,65 @@
   (let [^java.time.LocalDate localDate (-> datetime ->local-date)]
     (.with localDate (java.time.temporal.TemporalAdjusters/lastDayOfYear))))
 
+(defn- extract-datetime-component-simple
+  [extract-fn datetime]
+  (-> datetime
+      (->local-date-time)
+      (extract-fn)))
+
+;; Would be nice to type hint `time-component`. May need a macro for this.
+(defn- extract-datetime-component-complex
+  ([extract-fn datetime]
+   (extract-datetime-component-complex
+    extract-fn
+    datetime
+    {:as-number? false :as-class? false}))
+  ([extract-fn datetime {:keys [as-number? as-class?]}]
+   (let [^LocalDateTime ldt (->local-date-time datetime)
+         time-component (extract-fn ldt)]
+     (cond
+       as-number? (.getValue time-component) ;; reflection warning
+       as-class? time-component
+       :else (.toString ^java.lang.Object time-component)))))
+
+(def ^{:doc "Extracts year (as number) from any datetime."
+       :argslist '([datetime])}
+  year (partial extract-datetime-component-simple
+                #(.getYear ^LocalDateTime %)))
+
+(def ^{:doc "Extracts year (as number) from any datetime."
+       :argslist '([datetime])}
+  dayofyear (partial extract-datetime-component-simple
+                     #(.getYear ^LocalDateTime %)))
+
+(def ^{:doc "Extract month from any datetime."
+       :argslist '([datetime] [datetime {:keys [as-number? as-class?]}])}
+  month (partial
+         extract-datetime-component-complex
+         #(.getMonth ^LocalDateTime %)))
+
+(def ^{:doc "Extracts the day of the month from any datetime."
+       :argslist '([datetime])}
+  dayofmonth (partial extract-datetime-component-simple
+                      #(.getDayOfMonth ^LocalDateTime %)))
+
+(def ^{:doc "Extract the day of week from any datetime."
+       :argslist '([datetime] [datetime {:keys [as-number? as-class?]}])}
+  dayofweek (partial
+             extract-datetime-component-complex
+             #(.getDayOfWeek ^LocalDateTime %)))
+
+(def ^{:doc "Extracts the hour from any datetime." 
+       :arglists '([datetime])}
+  hour (partial extract-datetime-component-simple
+                  #(.getHour ^LocalDateTime %)))
+
+(def ^{:doc "Extracts the minute of hour (number) from any datetime."
+       :arglists '([datetime])}
+  minute (partial extract-datetime-component-simple
+                  #(.getMinute ^LocalDateTime %)))
+
+(def ^{:doc "Extracts the second of minute from any datetime."
+       :arglists '([datetime])}
+  seconds (partial extract-datetime-component-simple
+                  #(.getSecond ^LocalDateTime %)))

--- a/src/tablecloth/time/api/converters.clj
+++ b/src/tablecloth/time/api/converters.clj
@@ -1,5 +1,5 @@
 (ns tablecloth.time.api.converters
-  (:import [java.time Year Month LocalDateTime]
+  (:import [java.time Year]
            [org.threeten.extra YearWeek YearQuarter])
   (:require [tech.v3.datatype.datetime :as dtdt]
             [tech.v3.datatype :as dt]
@@ -175,65 +175,3 @@
   (let [^java.time.LocalDate localDate (-> datetime ->local-date)]
     (.with localDate (java.time.temporal.TemporalAdjusters/lastDayOfYear))))
 
-(defn- extract-datetime-component-simple
-  [extract-fn datetime]
-  (-> datetime
-      (->local-date-time)
-      (extract-fn)))
-
-;; Would be nice to type hint `time-component`. May need a macro for this.
-(defn- extract-datetime-component-complex
-  ([extract-fn datetime]
-   (extract-datetime-component-complex
-    extract-fn
-    datetime
-    {:as-number? false :as-class? false}))
-  ([extract-fn datetime {:keys [as-number? as-class?]}]
-   (let [^LocalDateTime ldt (->local-date-time datetime)
-         time-component (extract-fn ldt)]
-     (cond
-       as-number? (.getValue time-component) ;; reflection warning
-       as-class? time-component
-       :else (.toString ^java.lang.Object time-component)))))
-
-(def ^{:doc "Extracts year (as number) from any datetime."
-       :argslist '([datetime])}
-  year (partial extract-datetime-component-simple
-                #(.getYear ^LocalDateTime %)))
-
-(def ^{:doc "Extracts year (as number) from any datetime."
-       :argslist '([datetime])}
-  dayofyear (partial extract-datetime-component-simple
-                     #(.getYear ^LocalDateTime %)))
-
-(def ^{:doc "Extract month from any datetime."
-       :argslist '([datetime] [datetime {:keys [as-number? as-class?]}])}
-  month (partial
-         extract-datetime-component-complex
-         #(.getMonth ^LocalDateTime %)))
-
-(def ^{:doc "Extracts the day of the month from any datetime."
-       :argslist '([datetime])}
-  dayofmonth (partial extract-datetime-component-simple
-                      #(.getDayOfMonth ^LocalDateTime %)))
-
-(def ^{:doc "Extract the day of week from any datetime."
-       :argslist '([datetime] [datetime {:keys [as-number? as-class?]}])}
-  dayofweek (partial
-             extract-datetime-component-complex
-             #(.getDayOfWeek ^LocalDateTime %)))
-
-(def ^{:doc "Extracts the hour from any datetime." 
-       :arglists '([datetime])}
-  hour (partial extract-datetime-component-simple
-                  #(.getHour ^LocalDateTime %)))
-
-(def ^{:doc "Extracts the minute of hour (number) from any datetime."
-       :arglists '([datetime])}
-  minute (partial extract-datetime-component-simple
-                  #(.getMinute ^LocalDateTime %)))
-
-(def ^{:doc "Extracts the second of minute from any datetime."
-       :arglists '([datetime])}
-  seconds (partial extract-datetime-component-simple
-                  #(.getSecond ^LocalDateTime %)))

--- a/src/tablecloth/time/api/time_components.clj
+++ b/src/tablecloth/time/api/time_components.clj
@@ -50,10 +50,10 @@
              extract-datetime-component-complex
              #(.getDayOfWeek ^LocalDateTime %)))
 
-(def ^{:doc "Extracts the hour from any datetime." 
+(def ^{:doc "Extracts the hour from any datetime."
        :arglists '([datetime])}
   hour (partial extract-datetime-component-simple
-                  #(.getHour ^LocalDateTime %)))
+                #(.getHour ^LocalDateTime %)))
 
 (def ^{:doc "Extracts the minute of hour (number) from any datetime."
        :arglists '([datetime])}
@@ -63,4 +63,4 @@
 (def ^{:doc "Extracts the second of minute from any datetime."
        :arglists '([datetime])}
   secnd (partial extract-datetime-component-simple
-                  #(.getSecond ^LocalDateTime %)))
+                 #(.getSecond ^LocalDateTime %)))

--- a/src/tablecloth/time/api/time_components.clj
+++ b/src/tablecloth/time/api/time_components.clj
@@ -1,0 +1,66 @@
+(ns tablecloth.time.api.time-components
+  (:import [java.time Month LocalDateTime])
+  (:require [tablecloth.time.api.converters :refer [->local-date-time]]))
+
+(defn- extract-datetime-component-simple
+  [extract-fn datetime]
+  (-> datetime
+      (->local-date-time)
+      (extract-fn)))
+
+;; Would be nice to type hint `time-component`. May need a macro for this.
+(defn- extract-datetime-component-complex
+  ([extract-fn datetime]
+   (extract-datetime-component-complex
+    extract-fn
+    datetime
+    {:as-number? false :as-class? false}))
+  ([extract-fn datetime {:keys [as-number? as-class?]}]
+   (let [^LocalDateTime ldt (->local-date-time datetime)
+         time-component (extract-fn ldt)]
+     (cond
+       as-number? (.getValue time-component) ;; reflection warning
+       as-class? time-component
+       :else (.toString ^java.lang.Object time-component)))))
+
+(def ^{:doc "Extracts year (as number) from any datetime."
+       :argslist '([datetime])}
+  year (partial extract-datetime-component-simple
+                #(.getYear ^LocalDateTime %)))
+
+(def ^{:doc "Extracts year (as number) from any datetime."
+       :argslist '([datetime])}
+  dayofyear (partial extract-datetime-component-simple
+                     #(.getDayOfYear ^LocalDateTime %)))
+
+(def ^{:doc "Extract month from any datetime."
+       :argslist '([datetime] [datetime {:keys [as-number? as-class?]}])}
+  month (partial
+         extract-datetime-component-complex
+         #(.getMonth ^LocalDateTime %)))
+
+(def ^{:doc "Extracts the day of the month from any datetime."
+       :argslist '([datetime])}
+  dayofmonth (partial extract-datetime-component-simple
+                      #(.getDayOfMonth ^LocalDateTime %)))
+
+(def ^{:doc "Extract the day of week from any datetime."
+       :argslist '([datetime] [datetime {:keys [as-number? as-class?]}])}
+  dayofweek (partial
+             extract-datetime-component-complex
+             #(.getDayOfWeek ^LocalDateTime %)))
+
+(def ^{:doc "Extracts the hour from any datetime." 
+       :arglists '([datetime])}
+  hour (partial extract-datetime-component-simple
+                  #(.getHour ^LocalDateTime %)))
+
+(def ^{:doc "Extracts the minute of hour (number) from any datetime."
+       :arglists '([datetime])}
+  minute (partial extract-datetime-component-simple
+                  #(.getMinute ^LocalDateTime %)))
+
+(def ^{:doc "Extracts the second of minute from any datetime."
+       :arglists '([datetime])}
+  secnd (partial extract-datetime-component-simple
+                  #(.getSecond ^LocalDateTime %)))

--- a/src/tablecloth/time/api/time_components.clj
+++ b/src/tablecloth/time/api/time_components.clj
@@ -1,5 +1,5 @@
 (ns tablecloth.time.api.time-components
-  (:import [java.time Month LocalDateTime])
+  (:import [java.time LocalDateTime])
   (:require [tablecloth.time.api.converters :refer [->local-date-time]]))
 
 (defn- extract-datetime-component-simple

--- a/test/tablecloth/time/api/time_components_test.clj
+++ b/test/tablecloth/time/api/time_components_test.clj
@@ -1,0 +1,37 @@
+(ns tablecloth.time.api.time-components-test
+  (:require [clojure.test :refer [testing deftest is function?]]
+            [tablecloth.time.api.time-components :refer [year dayofyear
+                                                         month dayofmonth
+                                                         dayofweek hour
+                                                         minute secnd]]))
+
+(deftest test-year
+  (is (= 1970 (year #time/date "1970-01-01"))))
+
+(deftest test-dayofyear
+  (is (= 1 (dayofyear #time/date "1970-01-01"))))
+
+(deftest test-month
+  (is (= "JANUARY" (month #time/date "1970-01-01")))
+  (is (= 1 (month #time/date "1970-01-01" {:as-number? true})))
+  (is (= (.getMonth #time/date "1970-01-01")
+         (month #time/date "1970-01-01" {:as-class? true}))))
+
+(deftest test-dayofmonth
+  (is (= 1 (dayofmonth #time/date "1970-01-01"))))
+
+(deftest test-dayofweek
+  (is (= "THURSDAY" (dayofweek #time/date "1970-01-01")))
+  (is (= 4 (dayofweek #time/date "1970-01-01" {:as-number? true})))
+  (is (= (.getDayOfWeek #time/date "1970-01-01")
+         (dayofweek #time/date "1970-01-01" {:as-class? true}))))
+
+(deftest test-hour
+  (is (= 13 (hour #time/date-time "1970-01-01T13:13"))))
+
+(deftest test-minute
+  (is (= 13 (minute #time/date-time "1970-01-01T13:13"))))
+
+(deftest test-secnd
+  (is (= 13 (secnd #time/instant "1970-01-01T13:13:13Z"))))
+

--- a/test/tablecloth/time/api/time_components_test.clj
+++ b/test/tablecloth/time/api/time_components_test.clj
@@ -1,5 +1,5 @@
 (ns tablecloth.time.api.time-components-test
-  (:require [clojure.test :refer [testing deftest is function?]]
+  (:require [clojure.test :refer [deftest is]]
             [tablecloth.time.api.time-components :refer [year dayofyear
                                                          month dayofmonth
                                                          dayofweek hour


### PR DESCRIPTION
### Goal / Problem

When working with date times people may frequently want to extract pieces of a datetime. 

### Proposed Solution

These functions basically just take the strategy of converting anytime to a `java.time.LocalDateTime`. That java.time class has functions that allow you to extract most/all components, such as year, month, etc. 

Some of the components are always returned as ints by the functions on `java.time.LocalDateTime`.  Others are returned as other classes. For example `.getDayOfWeek` returns a `java.time.DayOfWeek`. For the latter, we will return strings by default, but provide the option to either return `:as-number?` or `:as-class?`. For the former, we will return ints.

I tried to write a helper fn that can be used with `partial` to avoid repetition. So `extract-datetime-component-simple` can take an anonymous function with the extract call (e.g. `#(.getYear %)`) and returns an int. And `extract-datetime-component-complex` yields a function that takes the more complex set of options described above.

### Work remaining
* Might be good to figure out a way to prevent type reflection for `extract-datetime-component-complex`.

### Open Questions