### PR TITLE
Ethan/some library upgrades

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -1,4 +1,5 @@
 {:linters
- {:unresolved-var {:level :info} ;; set b/c seems to be triggered by fns exported with tech.datatype.export-symbols/export-symbols fn.
-  :unresolved-symbol {:level :info}
-  }}
+ ;; add modifications to linting rules here
+ ;; see example below
+ #_{:unresolved-var {:level :info}
+  :unresolved-symbol {:level :info}}}

--- a/deps.edn
+++ b/deps.edn
@@ -1,6 +1,6 @@
 {:deps
  {org.clojure/clojure         {:mvn/version "1.10.2"}
-  scicloj/tablecloth          {:mvn/version "6.00-beta-10"}
+  scicloj/tablecloth          {:mvn/version "6.031"}
   org.threeten/threeten-extra {:mvn/version "1.5.0"}
   time-literals/time-literals {:mvn/version "0.1.5"}}
  :aliases

--- a/deps.edn
+++ b/deps.edn
@@ -5,6 +5,6 @@
   time-literals/time-literals {:mvn/version "0.1.5"}}
  :aliases
  {:dev
-  {:extra-deps {clj-kondo         {:mvn/version "2021.03.03"}
+  {:extra-deps {clj-kondo         {:mvn/version "2021.12.01"}
                 scicloj/notespace {:mvn/version "3-beta3"}
                 midje/midje       {:mvn/version "1.9.10"}}}}}

--- a/deps.edn
+++ b/deps.edn
@@ -7,4 +7,4 @@
  {:dev
   {:extra-deps {clj-kondo         {:mvn/version "2021.12.01"}
                 scicloj/notespace {:mvn/version "3-beta3"}
-                midje/midje       {:mvn/version "1.9.10"}}}}}
+                midje/midje       {:mvn/version "1.10.5"}}}}}


### PR DESCRIPTION
### Goal / Problem

Just upgrading some stuff:
* Upgrade to clj-kondo `2021-12-01` - An important upgrade because the upgrade solves the problem causing the unresolved var errors in clj-kondo for symbols exported with `export-symbols` in `tablecloth.time.api`.
* Because of the above, I removed the clj-kondo config that demoted the above errors to `:info` to avoid blocking the CI scripts.
* Upgrade tablecloth to `6.031`
* Upgrade midje to `1.10.5`