### PR TITLE
Bump tablecloth version & switch to snapshot version

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,6 +1,6 @@
 {:deps
  {org.clojure/clojure         {:mvn/version "1.10.2"}
-  scicloj/tablecloth          {:mvn/version "6.031"}
+  scicloj/tablecloth          {:mvn/version "6.051"}
   org.threeten/threeten-extra {:mvn/version "1.5.0"}
   time-literals/time-literals {:mvn/version "0.1.5"}}
  :aliases

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject org.scicloj/tablecloth.time "1.00-alpha-5"
+(defproject org.scicloj/tablecloth.time "1.00-alpha-5-SNAPSHOT"
   :description "A time series manipulation library built on top of tablecloth."
   :url "https://github.com/scicloj/tablecloth.time"
   :license {:name "The MIT Licence"

--- a/test/tablecloth/time/api/slice_test.clj
+++ b/test/tablecloth/time/api/slice_test.clj
@@ -69,7 +69,7 @@
                          #time/date "1970-01-02"
                          #time/date "1970-01-03"]
                      :B [4 5 6]})]
-    (is (instance? tech.v3.datatype.ListPersistentVector
+    (is (instance? tech.v3.datatype.list.ListImpl
                    (-> ds
                        (slice "1970-01-02" "1970-01-03" {:result-type :as-indexes}))))
     (is (instance? tech.v3.dataset.impl.dataset.Dataset


### PR DESCRIPTION
### Goal / Problem
Bumped tablecloth versin to `6.051` and switched to SNAPSHOT version on project.