### PR TITLE
Prepare 1.00-alpha-6 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,22 @@ and any standard clojure tests:
 lein midje
 ```
 
+#### Releasing to Clojars
+
+Publishing is currently manual.
+
+1. Update the version in `project.clj` (release versions should not include `-SNAPSHOT`).
+2. Run local checks:
+```bash
+lein lint
+lein midje
+```
+3. Deploy:
+```bash
+lein deploy clojars
+```
+4. After deploy, bump `project.clj` to the next `-SNAPSHOT` version for ongoing development.
+
 ## Contributing
 
 Development for this project happens in the SciCloj [fundamentals

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject org.scicloj/tablecloth.time "1.00-alpha-5-SNAPSHOT"
+(defproject org.scicloj/tablecloth.time "1.00-alpha-6"
   :description "A time series manipulation library built on top of tablecloth."
   :url "https://github.com/scicloj/tablecloth.time"
   :license {:name "The MIT Licence"
@@ -16,4 +16,3 @@
                                      ["run" "-m" "clj-kondo.main" "--lint" "src:test"]]}
                    :plugins [[lein-midje "3.2.1"]
                              [lein-cljfmt "0.7.0"]]}})
-


### PR DESCRIPTION
## Summary
- bump project version from 1.00-alpha-5 to 1.00-alpha-6
- add a Releasing to Clojars section in README with manual release steps

## Validation
- lein lint
- lein test