### PR TITLE
Bump version to 1.00-alpha-7-SNAPSHOT

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject org.scicloj/tablecloth.time "1.00-alpha-6"
+(defproject org.scicloj/tablecloth.time "1.00-alpha-7-SNAPSHOT"
   :description "A time series manipulation library built on top of tablecloth."
   :url "https://github.com/scicloj/tablecloth.time"
   :license {:name "The MIT Licence"


### PR DESCRIPTION
## Summary
- bump project version from 1.00-alpha-6 to 1.00-alpha-7-SNAPSHOT after the 1.00-alpha-6 Clojars release

## Validation
- lein lint